### PR TITLE
사용자 관리 API 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -42,7 +42,7 @@ dependencies {
     runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-jackson', version: '0.11.5'
 
     // QueryDSL
-    implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+    implementation "com.querydsl:querydsl-jpa:${dependencyManagement.importedProperties['querydsl.version']}:jakarta"
     annotationProcessor "com.querydsl:querydsl-apt:${dependencyManagement.importedProperties['querydsl.version']}:jakarta"
     annotationProcessor "jakarta.annotation:jakarta.annotation-api"
     annotationProcessor "jakarta.persistence:jakarta.persistence-api"

--- a/build.gradle
+++ b/build.gradle
@@ -35,6 +35,12 @@ dependencies {
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+    // QueryDSL
+    implementation "com.querydsl:querydsl-jpa:${dependencyManagement.importedProperties['querydsl.version']}:jakarta"
+    annotationProcessor "com.querydsl:querydsl-apt:${dependencyManagement.importedProperties['querydsl.version']}:jakarta"
+    annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+    annotationProcessor "jakarta.persistence:jakarta.persistence-api"
 }
 
 tasks.named('test') {

--- a/src/main/java/com/example/nurim/NurimApplication.java
+++ b/src/main/java/com/example/nurim/NurimApplication.java
@@ -2,8 +2,12 @@ package com.example.nurim;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.web.config.EnableSpringDataWebSupport;
+
+import static org.springframework.data.web.config.EnableSpringDataWebSupport.PageSerializationMode.VIA_DTO;
 
 @SpringBootApplication
+@EnableSpringDataWebSupport(pageSerializationMode = VIA_DTO)
 public class NurimApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/com/example/nurim/config/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/nurim/config/GlobalExceptionHandler.java
@@ -1,7 +1,9 @@
 package com.example.nurim.config;
 
+import com.example.nurim.domain.user.exception.UserException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 import java.util.HashMap;
@@ -9,6 +11,11 @@ import java.util.Map;
 
 @RestControllerAdvice
 public class GlobalExceptionHandler {
+
+    @ExceptionHandler
+    public ResponseEntity<Map<String, Object>> handleUserException(UserException e) {
+        return getErrorResponse(e.getStatus(), e.getMessage());
+    }
 
     public ResponseEntity<Map<String, Object>> getErrorResponse(HttpStatus status, String message){
         Map<String, Object> errorResponse = new HashMap<>();

--- a/src/main/java/com/example/nurim/config/JwtAuthenticationEntryPoint.java
+++ b/src/main/java/com/example/nurim/config/JwtAuthenticationEntryPoint.java
@@ -1,7 +1,6 @@
 package com.example.nurim.config;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/com/example/nurim/config/PersistenceConfig.java
+++ b/src/main/java/com/example/nurim/config/PersistenceConfig.java
@@ -1,9 +1,20 @@
 package com.example.nurim.config;
 
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @Configuration
 @EnableJpaAuditing
 public class PersistenceConfig {
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory() {
+        return new JPAQueryFactory(entityManager);
+    }
 }

--- a/src/main/java/com/example/nurim/config/PersistenceConfig.java
+++ b/src/main/java/com/example/nurim/config/PersistenceConfig.java
@@ -1,20 +1,9 @@
 package com.example.nurim.config;
 
-import com.querydsl.jpa.impl.JPAQueryFactory;
-import jakarta.persistence.EntityManager;
-import jakarta.persistence.PersistenceContext;
-import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @Configuration
 @EnableJpaAuditing
 public class PersistenceConfig {
-    @PersistenceContext
-    private EntityManager entityManager;
-
-    @Bean
-    public JPAQueryFactory jpaQueryFactory() {
-        return new JPAQueryFactory(entityManager);
-    }
 }

--- a/src/main/java/com/example/nurim/config/SecurityConfig.java
+++ b/src/main/java/com/example/nurim/config/SecurityConfig.java
@@ -22,7 +22,7 @@ public class SecurityConfig {
 
     private final JwtAuthenticationFilter jwtAuthenticationFilter;
     private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
-    private final AdminAccessDeniedHandler adminAccessDeniedHandler;
+    private final UserAccessDeniedHandler userAccessDeniedHandler;
 
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
@@ -43,7 +43,7 @@ public class SecurityConfig {
                 .addFilterBefore(jwtAuthenticationFilter, SecurityContextHolderAwareRequestFilter.class)
                 .exceptionHandling(ex -> ex
                         .authenticationEntryPoint(jwtAuthenticationEntryPoint)
-                        .accessDeniedHandler(adminAccessDeniedHandler))
+                        .accessDeniedHandler(userAccessDeniedHandler))
                 .build();
     }
 

--- a/src/main/java/com/example/nurim/config/SecurityConfig.java
+++ b/src/main/java/com/example/nurim/config/SecurityConfig.java
@@ -1,4 +1,18 @@
 package com.example.nurim.config;
 
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.crypto.factory.PasswordEncoderFactories;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+@Configuration
+@EnableWebSecurity
+@RequiredArgsConstructor
 public class SecurityConfig {
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return PasswordEncoderFactories.createDelegatingPasswordEncoder();
+    }
 }

--- a/src/main/java/com/example/nurim/config/SecurityConfig.java
+++ b/src/main/java/com/example/nurim/config/SecurityConfig.java
@@ -3,12 +3,14 @@ package com.example.nurim.config;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.crypto.factory.PasswordEncoderFactories;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
 @Configuration
 @EnableWebSecurity
+@EnableMethodSecurity(securedEnabled = true)
 @RequiredArgsConstructor
 public class SecurityConfig {
     @Bean

--- a/src/main/java/com/example/nurim/config/UserAccessDeniedHandler.java
+++ b/src/main/java/com/example/nurim/config/UserAccessDeniedHandler.java
@@ -16,7 +16,7 @@ import java.util.Map;
 
 @Component
 @RequiredArgsConstructor
-public class AdminAccessDeniedHandler implements AccessDeniedHandler {
+public class UserAccessDeniedHandler implements AccessDeniedHandler {
 
     private final ObjectMapper objectMapper;
 
@@ -26,7 +26,7 @@ public class AdminAccessDeniedHandler implements AccessDeniedHandler {
         response.setCharacterEncoding(StandardCharsets.UTF_8.name());
         response.setContentType(MediaType.APPLICATION_JSON_VALUE);
 
-        Map<String, Object> errorResponse = ErrorResponseUtil.getErrorResponse(HttpStatus.FORBIDDEN, "Admin Access Denied");
+        Map<String, Object> errorResponse = ErrorResponseUtil.getErrorResponse(HttpStatus.FORBIDDEN, "Access Denied");
         objectMapper.writeValue(response.getWriter(), errorResponse);
     }
 }

--- a/src/main/java/com/example/nurim/domain/application/dto/response/UserApplicationResponse.java
+++ b/src/main/java/com/example/nurim/domain/application/dto/response/UserApplicationResponse.java
@@ -1,5 +1,6 @@
 package com.example.nurim.domain.application.dto.response;
 
+import com.example.nurim.domain.application.enums.ApplicationStatus;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
@@ -10,6 +11,7 @@ import java.time.LocalDateTime;
 public class UserApplicationResponse {
     private final Long applicationId;
     private final LocalDateTime applicationCreatedAt;
+    private final ApplicationStatus status;
     private final LocalDateTime usageDateTime;
     private final Long programId;
     private final String programTitle;

--- a/src/main/java/com/example/nurim/domain/application/dto/response/UserApplicationResponse.java
+++ b/src/main/java/com/example/nurim/domain/application/dto/response/UserApplicationResponse.java
@@ -1,0 +1,17 @@
+package com.example.nurim.domain.application.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@AllArgsConstructor
+public class UserApplicationResponse {
+    private final Long applicationId;
+    private final LocalDateTime applicationCreatedAt;
+    private final LocalDateTime usageDateTime;
+    private final Long programId;
+    private final String programTitle;
+    private final LocalDateTime programDeletedAt;
+}

--- a/src/main/java/com/example/nurim/domain/application/repository/ApplicationCustomRepository.java
+++ b/src/main/java/com/example/nurim/domain/application/repository/ApplicationCustomRepository.java
@@ -1,0 +1,10 @@
+package com.example.nurim.domain.application.repository;
+
+import com.example.nurim.domain.application.dto.response.UserApplicationResponse;
+import com.example.nurim.domain.user.dto.request.FindApplicationRequest;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface ApplicationCustomRepository {
+    Page<UserApplicationResponse> findByUserId(Long userId, FindApplicationRequest request, Pageable pageable);
+}

--- a/src/main/java/com/example/nurim/domain/application/repository/ApplicationCustomRepositoryImpl.java
+++ b/src/main/java/com/example/nurim/domain/application/repository/ApplicationCustomRepositoryImpl.java
@@ -1,0 +1,80 @@
+package com.example.nurim.domain.application.repository;
+
+import com.example.nurim.domain.application.dto.response.UserApplicationResponse;
+import com.example.nurim.domain.application.enums.ApplicationStatus;
+import com.example.nurim.domain.user.dto.request.FindApplicationRequest;
+import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.Wildcard;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static com.example.nurim.domain.application.entity.QApplication.application;
+import static com.example.nurim.domain.program.entity.QProgram.program;
+import static com.example.nurim.domain.program.entity.QProgramDate.programDate;
+
+@RequiredArgsConstructor
+public class ApplicationCustomRepositoryImpl implements ApplicationCustomRepository {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public Page<UserApplicationResponse> findByUserId(Long userId, FindApplicationRequest request, Pageable pageable) {
+        List<UserApplicationResponse> applicationList = queryFactory
+                .select(Projections.constructor(UserApplicationResponse.class,
+                        application.id,
+                        application.createdAt,
+                        programDate.date,
+                        program.id,
+                        program.title,
+                        program.deletedAt
+                ))
+                .from(application)
+                .join(application.programDate, programDate)
+                .join(programDate.program, program)
+                .where(application.user.id.eq(userId),
+                        hasStatus(request.getStatus()),
+                        createdAtAfterOrOn(request.getCreatedFrom()),
+                        createdBeforeOrOn(request.getCreatedTo()),
+                        titleContains(request.getTitle()))
+                .orderBy(application.createdAt.desc())
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+
+        Long count = queryFactory.select(Wildcard.count)
+                .from(application)
+                .join(application.programDate, programDate)
+                .join(programDate.program, program)
+                .where(application.user.id.eq(userId),
+                        hasStatus(request.getStatus()),
+                        createdAtAfterOrOn(request.getCreatedFrom()),
+                        createdBeforeOrOn(request.getCreatedTo()),
+                        titleContains(request.getTitle()))
+                .fetchOne();
+
+        return new PageImpl<>(applicationList, pageable, count);
+    }
+
+    private BooleanExpression hasStatus(ApplicationStatus status) {
+        return status != null ? application.status.eq(status) : null;
+    }
+
+    private BooleanExpression createdAtAfterOrOn(LocalDateTime createdFrom) {
+        return createdFrom != null ? application.createdAt.goe(createdFrom) : null;
+    }
+
+    private BooleanExpression createdBeforeOrOn(LocalDateTime createdTo) {
+        return createdTo != null ? application.createdAt.loe(createdTo) : null;
+    }
+
+    private BooleanExpression titleContains(String title) {
+        return title != null ? program.title.contains(title) : null;
+    }
+}

--- a/src/main/java/com/example/nurim/domain/application/repository/ApplicationCustomRepositoryImpl.java
+++ b/src/main/java/com/example/nurim/domain/application/repository/ApplicationCustomRepositoryImpl.java
@@ -30,6 +30,7 @@ public class ApplicationCustomRepositoryImpl implements ApplicationCustomReposit
                 .select(Projections.constructor(UserApplicationResponse.class,
                         application.id,
                         application.createdAt,
+                        application.status,
                         programDate.date,
                         program.id,
                         program.title,

--- a/src/main/java/com/example/nurim/domain/application/repository/ApplicationRepository.java
+++ b/src/main/java/com/example/nurim/domain/application/repository/ApplicationRepository.java
@@ -6,7 +6,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
-public interface ApplicationRepository extends JpaRepository<Application, Long> {
+public interface ApplicationRepository extends JpaRepository<Application, Long>, ApplicationCustomRepository {
     @Query("SELECT CASE WHEN COUNT(a) > 0 THEN TRUE ELSE FALSE END " +
             "FROM Application a " +
             "JOIN a.programDate d " +

--- a/src/main/java/com/example/nurim/domain/application/repository/ApplicationRepository.java
+++ b/src/main/java/com/example/nurim/domain/application/repository/ApplicationRepository.java
@@ -7,9 +7,11 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 public interface ApplicationRepository extends JpaRepository<Application, Long>, ApplicationCustomRepository {
-    @Query("SELECT CASE WHEN COUNT(a) > 0 THEN TRUE ELSE FALSE END " +
-            "FROM Application a " +
-            "JOIN a.programDate d " +
-            "WHERE a.user.id = :userId AND a.status = 'COMPLETE' AND d.date > CURRENT_TIMESTAMP")
+    @Query("""
+            SELECT CASE WHEN COUNT(a) > 0 THEN TRUE ELSE FALSE END 
+            FROM Application a 
+            JOIN a.programDate d 
+            WHERE a.user.id = :userId AND a.status = 'COMPLETE' AND d.date > CURRENT_TIMESTAMP
+    """)
     Boolean existsUnusedApplicationByUserId(@Param("userId") Long userId);
 }

--- a/src/main/java/com/example/nurim/domain/application/repository/ApplicationRepository.java
+++ b/src/main/java/com/example/nurim/domain/application/repository/ApplicationRepository.java
@@ -3,6 +3,13 @@ package com.example.nurim.domain.application.repository;
 
 import com.example.nurim.domain.application.entity.Application;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface ApplicationRepository extends JpaRepository<Application, Long> {
+    @Query("SELECT CASE WHEN COUNT(a) > 0 THEN TRUE ELSE FALSE END " +
+            "FROM Application a " +
+            "JOIN a.programDate d " +
+            "WHERE a.user.id = :userId AND a.status = 'COMPLETE' AND d.date > CURRENT_TIMESTAMP")
+    Boolean existsUnusedApplicationByUserId(@Param("userId") Long userId);
 }

--- a/src/main/java/com/example/nurim/domain/common/annotation/HasUserRole.java
+++ b/src/main/java/com/example/nurim/domain/common/annotation/HasUserRole.java
@@ -1,0 +1,13 @@
+package com.example.nurim.domain.common.annotation;
+
+import org.springframework.security.access.prepost.PreAuthorize;
+
+import java.lang.annotation.*;
+
+@Target({ElementType.METHOD, ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@Inherited
+@Documented
+@PreAuthorize("hasRole(T(com.example.nurim.domain.user.enums.UserRole).ROLE_USER.name())")
+public @interface HasUserRole {
+}

--- a/src/main/java/com/example/nurim/domain/review/dto/response/UserReviewResponse.java
+++ b/src/main/java/com/example/nurim/domain/review/dto/response/UserReviewResponse.java
@@ -1,0 +1,18 @@
+package com.example.nurim.domain.review.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@AllArgsConstructor
+public class UserReviewResponse {
+    private final Long reviewId;
+    private final String contents;
+    private final Double rating;
+    private final LocalDateTime createdAt;
+    private final Long programId;
+    private final String programTitle;
+    private final LocalDateTime programDeletedAt;
+}

--- a/src/main/java/com/example/nurim/domain/review/dto/response/UserReviewResponse.java
+++ b/src/main/java/com/example/nurim/domain/review/dto/response/UserReviewResponse.java
@@ -1,18 +1,13 @@
 package com.example.nurim.domain.review.dto.response;
 
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-
 import java.time.LocalDateTime;
 
-@Getter
-@AllArgsConstructor
-public class UserReviewResponse {
-    private final Long reviewId;
-    private final String contents;
-    private final Double rating;
-    private final LocalDateTime createdAt;
-    private final Long programId;
-    private final String programTitle;
-    private final LocalDateTime programDeletedAt;
+public interface UserReviewResponse {
+    Long getReviewId();
+    String getContents();
+    Double getRating();
+    LocalDateTime getCreatedAt();
+    Long getProgramId();
+    String getProgramTitle();
+    LocalDateTime getProgramDeletedAt();
 }

--- a/src/main/java/com/example/nurim/domain/review/entity/Review.java
+++ b/src/main/java/com/example/nurim/domain/review/entity/Review.java
@@ -1,5 +1,6 @@
 package com.example.nurim.domain.review.entity;
 
+import com.example.nurim.domain.common.entity.Timestamped;
 import com.example.nurim.domain.program.entity.Program;
 import com.example.nurim.domain.user.entity.User;
 import jakarta.persistence.*;
@@ -12,7 +13,7 @@ import java.time.LocalDateTime;
 @Entity
 @NoArgsConstructor
 @Table(name = "reviews")
-public class Review {
+public class Review extends Timestamped {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/example/nurim/domain/review/repository/ReviewRepository.java
+++ b/src/main/java/com/example/nurim/domain/review/repository/ReviewRepository.java
@@ -1,7 +1,19 @@
 package com.example.nurim.domain.review.repository;
 
+import com.example.nurim.domain.review.dto.response.UserReviewResponse;
 import com.example.nurim.domain.review.entity.Review;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface ReviewRepository extends JpaRepository<Review, Long> {
+
+    @Query("SELECT new com.example.nurim.domain.review.dto.response.UserReviewResponse(" +
+            "r.id, r.contents, r.rating, r.createdAt, p.id, p.title, p.deletedAt) " +
+            "FROM Review r " +
+            "JOIN r.program p " +
+            "WHERE r.user.id = :userId AND r.deletedAt IS NULL")
+    Page<UserReviewResponse> findActiveByUserId(@Param("userId") Long userId, Pageable pageable);
 }

--- a/src/main/java/com/example/nurim/domain/review/repository/ReviewRepository.java
+++ b/src/main/java/com/example/nurim/domain/review/repository/ReviewRepository.java
@@ -10,10 +10,12 @@ import org.springframework.data.repository.query.Param;
 
 public interface ReviewRepository extends JpaRepository<Review, Long> {
 
-    @Query("SELECT new com.example.nurim.domain.review.dto.response.UserReviewResponse(" +
-            "r.id, r.contents, r.rating, r.createdAt, p.id, p.title, p.deletedAt) " +
-            "FROM Review r " +
-            "JOIN r.program p " +
-            "WHERE r.user.id = :userId AND r.deletedAt IS NULL")
+    @Query("""
+            SELECT r.id AS reviewId, r.contents AS contents, r.rating AS rating, r.createdAt AS createdAt, 
+                   p.id AS programId, p.title AS programTitle, p.deletedAt AS programDeletedAt
+            FROM Review r 
+            JOIN r.program p 
+            WHERE r.user.id = :userId AND r.deletedAt IS NULL
+    """)
     Page<UserReviewResponse> findActiveByUserId(@Param("userId") Long userId, Pageable pageable);
 }

--- a/src/main/java/com/example/nurim/domain/user/controller/UserController.java
+++ b/src/main/java/com/example/nurim/domain/user/controller/UserController.java
@@ -1,11 +1,15 @@
 package com.example.nurim.domain.user.controller;
 
 import com.example.nurim.domain.common.dto.AuthUser;
+import com.example.nurim.domain.review.dto.response.UserReviewResponse;
 import com.example.nurim.domain.user.dto.request.UpdateNameRequest;
 import com.example.nurim.domain.user.dto.request.UpdatePasswordRequest;
 import com.example.nurim.domain.user.service.UserService;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.Min;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.security.access.annotation.Secured;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
@@ -13,6 +17,10 @@ import org.springframework.web.bind.annotation.*;
 @RequestMapping("/users")
 @RequiredArgsConstructor
 public class UserController {
+
+    private static final String FIRST_PAGE = "1";
+    private static final String DEFAULT_SIZE = "10";
+    private static final String ROLE_USER = "ROLE_USER";
 
     private final UserService userService;
 
@@ -35,5 +43,15 @@ public class UserController {
     @DeleteMapping
     public void deleteUser(@AuthenticationPrincipal AuthUser authUser) {
         userService.deleteUser(authUser.getId());
+    }
+
+    @Secured(ROLE_USER)
+    @GetMapping("/reviews")
+    public Page<UserReviewResponse> findReviews(
+            @AuthenticationPrincipal AuthUser authUser,
+            @RequestParam(defaultValue = FIRST_PAGE) @Min(1) Integer page,
+            @RequestParam(defaultValue = DEFAULT_SIZE) @Min(1) Integer size
+    ) {
+        return userService.findReviews(authUser.getId(), page, size);
     }
 }

--- a/src/main/java/com/example/nurim/domain/user/controller/UserController.java
+++ b/src/main/java/com/example/nurim/domain/user/controller/UserController.java
@@ -1,4 +1,28 @@
 package com.example.nurim.domain.user.controller;
 
+import com.example.nurim.domain.common.dto.AuthUser;
+import com.example.nurim.domain.user.dto.request.UpdateNameRequest;
+import com.example.nurim.domain.user.service.UserService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/users")
+@RequiredArgsConstructor
 public class UserController {
+
+    private final UserService userService;
+
+    @PatchMapping("/name")
+    public void updateName(
+            @AuthenticationPrincipal AuthUser authUser,
+            @Valid @RequestBody UpdateNameRequest request
+    ) {
+        userService.updateName(authUser.getId(), request);
+    }
 }

--- a/src/main/java/com/example/nurim/domain/user/controller/UserController.java
+++ b/src/main/java/com/example/nurim/domain/user/controller/UserController.java
@@ -1,6 +1,7 @@
 package com.example.nurim.domain.user.controller;
 
 import com.example.nurim.domain.application.dto.response.UserApplicationResponse;
+import com.example.nurim.domain.common.annotation.HasUserRole;
 import com.example.nurim.domain.common.dto.AuthUser;
 import com.example.nurim.domain.review.dto.response.UserReviewResponse;
 import com.example.nurim.domain.user.dto.request.FindApplicationRequest;
@@ -11,7 +12,6 @@ import jakarta.validation.Valid;
 import jakarta.validation.constraints.Min;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
-import org.springframework.security.access.annotation.Secured;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
@@ -22,7 +22,6 @@ public class UserController {
 
     private static final String FIRST_PAGE = "1";
     private static final String DEFAULT_SIZE = "10";
-    private static final String ROLE_USER = "ROLE_USER";
 
     private final UserService userService;
 
@@ -47,7 +46,7 @@ public class UserController {
         userService.deleteUser(authUser.getId());
     }
 
-    @Secured(ROLE_USER)
+    @HasUserRole
     @GetMapping("/reviews")
     public Page<UserReviewResponse> findReviews(
             @AuthenticationPrincipal AuthUser authUser,
@@ -57,7 +56,7 @@ public class UserController {
         return userService.findReviews(authUser.getId(), page, size);
     }
 
-    @Secured(ROLE_USER)
+    @HasUserRole
     @GetMapping("/applications")
     public Page<UserApplicationResponse> findApplications(
             @AuthenticationPrincipal AuthUser authUser,

--- a/src/main/java/com/example/nurim/domain/user/controller/UserController.java
+++ b/src/main/java/com/example/nurim/domain/user/controller/UserController.java
@@ -2,6 +2,7 @@ package com.example.nurim.domain.user.controller;
 
 import com.example.nurim.domain.common.dto.AuthUser;
 import com.example.nurim.domain.user.dto.request.UpdateNameRequest;
+import com.example.nurim.domain.user.dto.request.UpdatePasswordRequest;
 import com.example.nurim.domain.user.service.UserService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -24,5 +25,13 @@ public class UserController {
             @Valid @RequestBody UpdateNameRequest request
     ) {
         userService.updateName(authUser.getId(), request);
+    }
+
+    @PatchMapping("/password")
+    public void updatePassword(
+            @AuthenticationPrincipal AuthUser authUser,
+            @Valid @RequestBody UpdatePasswordRequest request
+    ) {
+        userService.updatePassword(authUser.getId(), request);
     }
 }

--- a/src/main/java/com/example/nurim/domain/user/controller/UserController.java
+++ b/src/main/java/com/example/nurim/domain/user/controller/UserController.java
@@ -7,10 +7,7 @@ import com.example.nurim.domain.user.service.UserService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.PatchMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/users")
@@ -33,5 +30,10 @@ public class UserController {
             @Valid @RequestBody UpdatePasswordRequest request
     ) {
         userService.updatePassword(authUser.getId(), request);
+    }
+
+    @DeleteMapping
+    public void deleteUser(@AuthenticationPrincipal AuthUser authUser) {
+        userService.deleteUser(authUser.getId());
     }
 }

--- a/src/main/java/com/example/nurim/domain/user/controller/UserController.java
+++ b/src/main/java/com/example/nurim/domain/user/controller/UserController.java
@@ -1,7 +1,9 @@
 package com.example.nurim.domain.user.controller;
 
+import com.example.nurim.domain.application.dto.response.UserApplicationResponse;
 import com.example.nurim.domain.common.dto.AuthUser;
 import com.example.nurim.domain.review.dto.response.UserReviewResponse;
+import com.example.nurim.domain.user.dto.request.FindApplicationRequest;
 import com.example.nurim.domain.user.dto.request.UpdateNameRequest;
 import com.example.nurim.domain.user.dto.request.UpdatePasswordRequest;
 import com.example.nurim.domain.user.service.UserService;
@@ -53,5 +55,16 @@ public class UserController {
             @RequestParam(defaultValue = DEFAULT_SIZE) @Min(1) Integer size
     ) {
         return userService.findReviews(authUser.getId(), page, size);
+    }
+
+    @Secured(ROLE_USER)
+    @GetMapping("/applications")
+    public Page<UserApplicationResponse> findApplications(
+            @AuthenticationPrincipal AuthUser authUser,
+            @RequestParam(defaultValue = FIRST_PAGE) @Min(1) Integer page,
+            @RequestParam(defaultValue = DEFAULT_SIZE) @Min(1) Integer size,
+            @ModelAttribute FindApplicationRequest request
+    ) {
+        return userService.findApplications(authUser.getId(), page, size, request);
     }
 }

--- a/src/main/java/com/example/nurim/domain/user/dto/request/FindApplicationRequest.java
+++ b/src/main/java/com/example/nurim/domain/user/dto/request/FindApplicationRequest.java
@@ -1,0 +1,16 @@
+package com.example.nurim.domain.user.dto.request;
+
+import com.example.nurim.domain.application.enums.ApplicationStatus;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@AllArgsConstructor
+public class FindApplicationRequest {
+    private final LocalDateTime createdFrom;
+    private final LocalDateTime createdTo;
+    private final String title;
+    private final ApplicationStatus status;
+}

--- a/src/main/java/com/example/nurim/domain/user/dto/request/UpdateNameRequest.java
+++ b/src/main/java/com/example/nurim/domain/user/dto/request/UpdateNameRequest.java
@@ -1,0 +1,12 @@
+package com.example.nurim.domain.user.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class UpdateNameRequest {
+    @NotBlank
+    private final String name;
+}

--- a/src/main/java/com/example/nurim/domain/user/dto/request/UpdatePasswordRequest.java
+++ b/src/main/java/com/example/nurim/domain/user/dto/request/UpdatePasswordRequest.java
@@ -1,0 +1,14 @@
+package com.example.nurim.domain.user.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class UpdatePasswordRequest {
+    @NotBlank
+    private final String oldPassword;
+    @NotBlank
+    private final String newPassword;
+}

--- a/src/main/java/com/example/nurim/domain/user/entity/User.java
+++ b/src/main/java/com/example/nurim/domain/user/entity/User.java
@@ -7,6 +7,7 @@ import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 import java.time.LocalDateTime;
 
@@ -27,6 +28,7 @@ public class User extends Timestamped {
     private String password;
 
     @Column(nullable = false)
+    @Setter
     private String name;
 
     @Enumerated(EnumType.STRING)

--- a/src/main/java/com/example/nurim/domain/user/entity/User.java
+++ b/src/main/java/com/example/nurim/domain/user/entity/User.java
@@ -42,4 +42,8 @@ public class User extends Timestamped {
         this.password = password;
         this.name = name;
     }
+
+    public void setDeleted() {
+        this.deletedAt = LocalDateTime.now();
+    }
 }

--- a/src/main/java/com/example/nurim/domain/user/entity/User.java
+++ b/src/main/java/com/example/nurim/domain/user/entity/User.java
@@ -25,6 +25,7 @@ public class User extends Timestamped {
     private String email;
 
     @Column(nullable = false)
+    @Setter
     private String password;
 
     @Column(nullable = false)

--- a/src/main/java/com/example/nurim/domain/user/exception/UserException.java
+++ b/src/main/java/com/example/nurim/domain/user/exception/UserException.java
@@ -1,0 +1,14 @@
+package com.example.nurim.domain.user.exception;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public class UserException extends RuntimeException {
+    private final HttpStatus status;
+
+    public UserException(HttpStatus status, String message) {
+        super(message);
+        this.status = status;
+    }
+}

--- a/src/main/java/com/example/nurim/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/example/nurim/domain/user/repository/UserRepository.java
@@ -1,7 +1,15 @@
 package com.example.nurim.domain.user.repository;
 
 import com.example.nurim.domain.user.entity.User;
+import com.example.nurim.domain.user.exception.UserException;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.http.HttpStatus;
+
+import java.util.Optional;
 
 public interface UserRepository extends JpaRepository<User, Long> {
+    Optional<User> findByIdAndDeletedAtIsNull(Long id);
+    default User findActiveByIdOrElseThrow(Long id) {
+        return findByIdAndDeletedAtIsNull(id).orElseThrow(() -> new UserException(HttpStatus.NOT_FOUND, "User not found"));
+    }
 }

--- a/src/main/java/com/example/nurim/domain/user/service/UserService.java
+++ b/src/main/java/com/example/nurim/domain/user/service/UserService.java
@@ -1,8 +1,10 @@
 package com.example.nurim.domain.user.service;
 
+import com.example.nurim.domain.application.dto.response.UserApplicationResponse;
 import com.example.nurim.domain.application.repository.ApplicationRepository;
 import com.example.nurim.domain.review.dto.response.UserReviewResponse;
 import com.example.nurim.domain.review.repository.ReviewRepository;
+import com.example.nurim.domain.user.dto.request.FindApplicationRequest;
 import com.example.nurim.domain.user.dto.request.UpdateNameRequest;
 import com.example.nurim.domain.user.dto.request.UpdatePasswordRequest;
 import com.example.nurim.domain.user.entity.User;
@@ -54,6 +56,12 @@ public class UserService {
     public Page<UserReviewResponse> findReviews(Long userId, Integer page, Integer size) {
         Pageable pageable = PageRequest.of(page - 1, size, Sort.by("createdAt").descending());
         return reviewRepository.findActiveByUserId(userId, pageable);
+    }
+
+    @Transactional(readOnly = true)
+    public Page<UserApplicationResponse> findApplications(Long userId, Integer page, Integer size, FindApplicationRequest request) {
+        Pageable pageable = PageRequest.of(page - 1, size, Sort.by("createdAt").descending());
+        return applicationRepository.findByUserId(userId, request, pageable);
     }
 
     private void validateCurrentPassword(String inputPassword, String currentPassword) {

--- a/src/main/java/com/example/nurim/domain/user/service/UserService.java
+++ b/src/main/java/com/example/nurim/domain/user/service/UserService.java
@@ -1,5 +1,6 @@
 package com.example.nurim.domain.user.service;
 
+import com.example.nurim.domain.application.repository.ApplicationRepository;
 import com.example.nurim.domain.user.dto.request.UpdateNameRequest;
 import com.example.nurim.domain.user.dto.request.UpdatePasswordRequest;
 import com.example.nurim.domain.user.entity.User;
@@ -16,6 +17,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class UserService {
 
     private final UserRepository userRepository;
+    private final ApplicationRepository applicationRepository;
     private final PasswordEncoder passwordEncoder;
 
     @Transactional
@@ -34,6 +36,13 @@ public class UserService {
         user.setPassword(passwordEncoder.encode(request.getNewPassword()));
     }
 
+    @Transactional
+    public void deleteUser(Long userId) {
+        User user = userRepository.findActiveByIdOrElseThrow(userId);
+        validateNoUnusedApplications(userId);
+        user.setDeleted();
+    }
+
     private void validateCurrentPassword(String inputPassword, String currentPassword) {
         if (!passwordEncoder.matches(inputPassword, currentPassword)) {
             throw new UserException(HttpStatus.BAD_REQUEST, "Current password is incorrect");
@@ -43,6 +52,12 @@ public class UserService {
     private void validateNewPassword(String newPassword, String currentPassword) {
         if (newPassword.equals(currentPassword)) {
             throw new UserException(HttpStatus.BAD_REQUEST, "New password cannot be the same as the current password");
+        }
+    }
+
+    private void validateNoUnusedApplications(Long userId) {
+        if (applicationRepository.existsUnusedApplicationByUserId(userId)) {
+            throw new UserException(HttpStatus.BAD_REQUEST, "Unused application exists, account deletion is not allowed");
         }
     }
 }

--- a/src/main/java/com/example/nurim/domain/user/service/UserService.java
+++ b/src/main/java/com/example/nurim/domain/user/service/UserService.java
@@ -1,4 +1,21 @@
 package com.example.nurim.domain.user.service;
 
+import com.example.nurim.domain.user.dto.request.UpdateNameRequest;
+import com.example.nurim.domain.user.entity.User;
+import com.example.nurim.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
 public class UserService {
+
+    private final UserRepository userRepository;
+
+    @Transactional
+    public void updateName(Long userId, UpdateNameRequest request) {
+        User user = userRepository.findActiveByIdOrElseThrow(userId);
+        user.setName(request.getName());
+    }
 }

--- a/src/main/java/com/example/nurim/domain/user/service/UserService.java
+++ b/src/main/java/com/example/nurim/domain/user/service/UserService.java
@@ -1,12 +1,18 @@
 package com.example.nurim.domain.user.service;
 
 import com.example.nurim.domain.application.repository.ApplicationRepository;
+import com.example.nurim.domain.review.dto.response.UserReviewResponse;
+import com.example.nurim.domain.review.repository.ReviewRepository;
 import com.example.nurim.domain.user.dto.request.UpdateNameRequest;
 import com.example.nurim.domain.user.dto.request.UpdatePasswordRequest;
 import com.example.nurim.domain.user.entity.User;
 import com.example.nurim.domain.user.exception.UserException;
 import com.example.nurim.domain.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
@@ -18,6 +24,7 @@ public class UserService {
 
     private final UserRepository userRepository;
     private final ApplicationRepository applicationRepository;
+    private final ReviewRepository reviewRepository;
     private final PasswordEncoder passwordEncoder;
 
     @Transactional
@@ -41,6 +48,12 @@ public class UserService {
         User user = userRepository.findActiveByIdOrElseThrow(userId);
         validateNoUnusedApplications(userId);
         user.setDeleted();
+    }
+
+    @Transactional(readOnly = true)
+    public Page<UserReviewResponse> findReviews(Long userId, Integer page, Integer size) {
+        Pageable pageable = PageRequest.of(page - 1, size, Sort.by("createdAt").descending());
+        return reviewRepository.findActiveByUserId(userId, pageable);
     }
 
     private void validateCurrentPassword(String inputPassword, String currentPassword) {

--- a/src/main/java/com/example/nurim/domain/user/service/UserService.java
+++ b/src/main/java/com/example/nurim/domain/user/service/UserService.java
@@ -1,9 +1,13 @@
 package com.example.nurim.domain.user.service;
 
 import com.example.nurim.domain.user.dto.request.UpdateNameRequest;
+import com.example.nurim.domain.user.dto.request.UpdatePasswordRequest;
 import com.example.nurim.domain.user.entity.User;
+import com.example.nurim.domain.user.exception.UserException;
 import com.example.nurim.domain.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -12,10 +16,33 @@ import org.springframework.transaction.annotation.Transactional;
 public class UserService {
 
     private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
 
     @Transactional
     public void updateName(Long userId, UpdateNameRequest request) {
         User user = userRepository.findActiveByIdOrElseThrow(userId);
         user.setName(request.getName());
+    }
+
+    @Transactional
+    public void updatePassword(Long userId, UpdatePasswordRequest request) {
+        User user = userRepository.findActiveByIdOrElseThrow(userId);
+
+        validateCurrentPassword(request.getOldPassword(), user.getPassword());
+        validateNewPassword(request.getNewPassword(), request.getOldPassword());
+
+        user.setPassword(passwordEncoder.encode(request.getNewPassword()));
+    }
+
+    private void validateCurrentPassword(String inputPassword, String currentPassword) {
+        if (!passwordEncoder.matches(inputPassword, currentPassword)) {
+            throw new UserException(HttpStatus.BAD_REQUEST, "Current password is incorrect");
+        }
+    }
+
+    private void validateNewPassword(String newPassword, String currentPassword) {
+        if (newPassword.equals(currentPassword)) {
+            throw new UserException(HttpStatus.BAD_REQUEST, "New password cannot be the same as the current password");
+        }
     }
 }

--- a/src/test/java/com/example/nurim/domain/user/service/UserServiceTest.java
+++ b/src/test/java/com/example/nurim/domain/user/service/UserServiceTest.java
@@ -47,10 +47,23 @@ class UserServiceTest {
     @Order(1)
     @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
     class UpdateNameTests {
+
+        private final UpdateNameRequest request = new UpdateNameRequest("newName");
+
         @Test
         @Order(1)
-        void 사용자_이름_수정_성공() {
-            UpdateNameRequest request = new UpdateNameRequest("newName");
+        void 이름_수정_사용자_없음_실패() {
+            given(userRepository.findActiveByIdOrElseThrow(anyLong()))
+                    .willThrow(new UserException(HttpStatus.NOT_FOUND, "User not found"));
+
+            UserException thrown = assertThrows(UserException.class, () -> userService.updateName(1L, request));
+            assertEquals(HttpStatus.NOT_FOUND, thrown.getStatus());
+            assertEquals("User not found", thrown.getMessage());
+        }
+
+        @Test
+        @Order(2)
+        void 이름_수정_성공() {
             User user = new User("temp@gmail.com", "encodedPassword", "name");
 
             given(userRepository.findActiveByIdOrElseThrow(anyLong())).willReturn(user);
@@ -70,6 +83,19 @@ class UserServiceTest {
 
         @Test
         @Order(1)
+        void 비밀번호_수정_사용자_없음_실패() {
+            UpdatePasswordRequest request = new UpdatePasswordRequest("oldPassword", "newPassword");
+
+            given(userRepository.findActiveByIdOrElseThrow(anyLong()))
+                    .willThrow(new UserException(HttpStatus.NOT_FOUND, "User not found"));
+
+            UserException thrown = assertThrows(UserException.class, () -> userService.updatePassword(1L, request));
+            assertEquals(HttpStatus.NOT_FOUND, thrown.getStatus());
+            assertEquals("User not found", thrown.getMessage());
+        }
+
+        @Test
+        @Order(2)
         void 비밀번호_수정_현재비밀번호_불일치_실패() {
             UpdatePasswordRequest request = new UpdatePasswordRequest("oldPassword", "newPassword");
 
@@ -82,7 +108,7 @@ class UserServiceTest {
         }
 
         @Test
-        @Order(2)
+        @Order(3)
         void 비밀번호_수정_새비밀번호_현재비밀번호_일치_실패() {
             UpdatePasswordRequest request = new UpdatePasswordRequest("samePassword", "samePassword");
 
@@ -95,7 +121,7 @@ class UserServiceTest {
         }
 
         @Test
-        @Order(3)
+        @Order(4)
         void 비밀번호_수정_성공() {
             String newEncodedPassword = "newEncodedPassword";
             UpdatePasswordRequest request = new UpdatePasswordRequest("oldPassword", "newPassword");
@@ -119,6 +145,17 @@ class UserServiceTest {
 
         @Test
         @Order(1)
+        void 회원탈퇴_사용자_없음_실패() {
+            given(userRepository.findActiveByIdOrElseThrow(anyLong()))
+                    .willThrow(new UserException(HttpStatus.NOT_FOUND, "User not found"));
+
+            UserException thrown = assertThrows(UserException.class, () -> userService.deleteUser(1L));
+            assertEquals(HttpStatus.NOT_FOUND, thrown.getStatus());
+            assertEquals("User not found", thrown.getMessage());
+        }
+
+        @Test
+        @Order(2)
         void 회원탈퇴_사용하지_않은_신청정보_존재_실패() {
             given(userRepository.findActiveByIdOrElseThrow(anyLong())).willReturn(user);
             given(applicationRepository.existsUnusedApplicationByUserId(anyLong())).willReturn(true);
@@ -129,7 +166,7 @@ class UserServiceTest {
         }
 
         @Test
-        @Order(2)
+        @Order(3)
         void 회원탈퇴_성공() {
             given(userRepository.findActiveByIdOrElseThrow(anyLong())).willReturn(user);
             given(applicationRepository.existsUnusedApplicationByUserId(anyLong())).willReturn(false);

--- a/src/test/java/com/example/nurim/domain/user/service/UserServiceTest.java
+++ b/src/test/java/com/example/nurim/domain/user/service/UserServiceTest.java
@@ -1,6 +1,7 @@
 package com.example.nurim.domain.user.service;
 
 import com.example.nurim.domain.application.dto.response.UserApplicationResponse;
+import com.example.nurim.domain.application.enums.ApplicationStatus;
 import com.example.nurim.domain.application.repository.ApplicationRepository;
 import com.example.nurim.domain.review.dto.response.UserReviewResponse;
 import com.example.nurim.domain.review.repository.ReviewRepository;
@@ -21,6 +22,7 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.stream.IntStream;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.*;
@@ -145,11 +147,9 @@ class UserServiceTest {
         @Test
         @Order(1)
         void 사용자_리뷰_조회_성공() {
-            LocalDateTime now = LocalDateTime.now();
-            List<UserReviewResponse> userReviewResponseList = List.of(
-                    new UserReviewResponse(1L, "review1", 5.0, now, 1L, "program1", null),
-                    new UserReviewResponse(2L, "review2", 4.5, now, 2L, "program2", null)
-            );
+            List<UserReviewResponse> userReviewResponseList = IntStream.rangeClosed(0, 2)
+                    .mapToObj(i -> mock(UserReviewResponse.class))
+                    .toList();
             Pageable pageable = PageRequest.of(0, 10, Sort.by("createdAt").descending());
             PageImpl<UserReviewResponse> userReviewResponsePage = new PageImpl<>(userReviewResponseList, pageable, userReviewResponseList.size());
 
@@ -177,8 +177,8 @@ class UserServiceTest {
             LocalDateTime createdAt = LocalDateTime.now();
             LocalDateTime usageDateTime = createdAt.plusDays(10);
             List<UserApplicationResponse> userApplicationResponseList = List.of(
-                    new UserApplicationResponse(1L, createdAt, usageDateTime, 1L, "program1", null),
-                    new UserApplicationResponse(2L, createdAt, usageDateTime,2L, "program2", null)
+                    new UserApplicationResponse(1L, createdAt, ApplicationStatus.COMPLETE, usageDateTime, 1L, "program1", null),
+                    new UserApplicationResponse(2L, createdAt, ApplicationStatus.COMPLETE, usageDateTime,2L, "program2", null)
             );
             Pageable pageable = PageRequest.of(0, 10, Sort.by("createdAt").descending());
             Page<UserApplicationResponse> userReviewResponsePage = new PageImpl<>(userApplicationResponseList, pageable, userApplicationResponseList.size());

--- a/src/test/java/com/example/nurim/domain/user/service/UserServiceTest.java
+++ b/src/test/java/com/example/nurim/domain/user/service/UserServiceTest.java
@@ -1,8 +1,10 @@
 package com.example.nurim.domain.user.service;
 
+import com.example.nurim.domain.application.dto.response.UserApplicationResponse;
 import com.example.nurim.domain.application.repository.ApplicationRepository;
 import com.example.nurim.domain.review.dto.response.UserReviewResponse;
 import com.example.nurim.domain.review.repository.ReviewRepository;
+import com.example.nurim.domain.user.dto.request.FindApplicationRequest;
 import com.example.nurim.domain.user.dto.request.UpdateNameRequest;
 import com.example.nurim.domain.user.dto.request.UpdatePasswordRequest;
 import com.example.nurim.domain.user.entity.User;
@@ -23,6 +25,7 @@ import java.util.List;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
 
 @TestClassOrder(ClassOrderer.OrderAnnotation.class)
 @ExtendWith(MockitoExtension.class)
@@ -153,6 +156,37 @@ class UserServiceTest {
             given(reviewRepository.findActiveByUserId(anyLong(), any(Pageable.class))).willReturn(userReviewResponsePage);
 
             Page<UserReviewResponse> result = userService.findReviews(1L, 1, 10);
+
+            assertNotNull(result);
+            assertEquals(userReviewResponsePage.getTotalElements(), result.getTotalElements());
+            assertEquals(userReviewResponsePage.getTotalPages(), result.getTotalPages());
+            assertEquals(userReviewResponsePage.getNumber(), result.getNumber());
+            assertEquals(userReviewResponsePage.getSize(), result.getSize());
+        }
+    }
+
+    @Nested
+    @Order(5)
+    @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+    class FindApplicationsTests {
+        @Test
+        @Order(1)
+        void 사용자_신청정보_조회_성공() {
+            FindApplicationRequest request = mock(FindApplicationRequest.class);
+
+            LocalDateTime createdAt = LocalDateTime.now();
+            LocalDateTime usageDateTime = createdAt.plusDays(10);
+            List<UserApplicationResponse> userApplicationResponseList = List.of(
+                    new UserApplicationResponse(1L, createdAt, usageDateTime, 1L, "program1", null),
+                    new UserApplicationResponse(2L, createdAt, usageDateTime,2L, "program2", null)
+            );
+            Pageable pageable = PageRequest.of(0, 10, Sort.by("createdAt").descending());
+            Page<UserApplicationResponse> userReviewResponsePage = new PageImpl<>(userApplicationResponseList, pageable, userApplicationResponseList.size());
+
+            given(applicationRepository.findByUserId(anyLong(), any(FindApplicationRequest.class), any(Pageable.class)))
+                    .willReturn(userReviewResponsePage);
+
+            Page<UserApplicationResponse> result = userService.findApplications(1L, 1, 10, request);
 
             assertNotNull(result);
             assertEquals(userReviewResponsePage.getTotalElements(), result.getTotalElements());

--- a/src/test/java/com/example/nurim/domain/user/service/UserServiceTest.java
+++ b/src/test/java/com/example/nurim/domain/user/service/UserServiceTest.java
@@ -1,5 +1,6 @@
 package com.example.nurim.domain.user.service;
 
+import com.example.nurim.domain.application.repository.ApplicationRepository;
 import com.example.nurim.domain.user.dto.request.UpdateNameRequest;
 import com.example.nurim.domain.user.dto.request.UpdatePasswordRequest;
 import com.example.nurim.domain.user.entity.User;
@@ -13,8 +14,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
@@ -26,6 +26,8 @@ class UserServiceTest {
     private UserRepository userRepository;
     @Mock
     private PasswordEncoder passwordEncoder;
+    @Mock
+    private ApplicationRepository applicationRepository;
     @InjectMocks
     private UserService userService;
 
@@ -93,6 +95,36 @@ class UserServiceTest {
             userService.updatePassword(1L, request);
 
             assertEquals(newEncodedPassword, user.getPassword());
+        }
+    }
+
+    @Nested
+    @Order(3)
+    @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+    class DeleteUserTests {
+
+        private final User user = new User("temp@gmail.com", "encodedPassword", "name");
+
+        @Test
+        @Order(1)
+        void 회원탈퇴_사용하지_않은_신청정보_존재_실패() {
+            given(userRepository.findActiveByIdOrElseThrow(anyLong())).willReturn(user);
+            given(applicationRepository.existsUnusedApplicationByUserId(anyLong())).willReturn(true);
+
+            UserException thrown = assertThrows(UserException.class, () -> userService.deleteUser(1L));
+            assertEquals(HttpStatus.BAD_REQUEST, thrown.getStatus());
+            assertEquals("Unused application exists, account deletion is not allowed", thrown.getMessage());
+        }
+
+        @Test
+        @Order(2)
+        void 회원탈퇴_성공() {
+            given(userRepository.findActiveByIdOrElseThrow(anyLong())).willReturn(user);
+            given(applicationRepository.existsUnusedApplicationByUserId(anyLong())).willReturn(false);
+
+            userService.deleteUser(1L);
+
+            assertNotNull(user.getDeletedAt());
         }
     }
 }

--- a/src/test/java/com/example/nurim/domain/user/service/UserServiceTest.java
+++ b/src/test/java/com/example/nurim/domain/user/service/UserServiceTest.java
@@ -1,6 +1,8 @@
 package com.example.nurim.domain.user.service;
 
 import com.example.nurim.domain.application.repository.ApplicationRepository;
+import com.example.nurim.domain.review.dto.response.UserReviewResponse;
+import com.example.nurim.domain.review.repository.ReviewRepository;
 import com.example.nurim.domain.user.dto.request.UpdateNameRequest;
 import com.example.nurim.domain.user.dto.request.UpdatePasswordRequest;
 import com.example.nurim.domain.user.entity.User;
@@ -11,12 +13,15 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.*;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
+import java.time.LocalDateTime;
+import java.util.List;
+
 import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.ArgumentMatchers.anyLong;
-import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.BDDMockito.given;
 
 @TestClassOrder(ClassOrderer.OrderAnnotation.class)
@@ -28,6 +33,8 @@ class UserServiceTest {
     private PasswordEncoder passwordEncoder;
     @Mock
     private ApplicationRepository applicationRepository;
+    @Mock
+    private ReviewRepository reviewRepository;
     @InjectMocks
     private UserService userService;
 
@@ -125,6 +132,33 @@ class UserServiceTest {
             userService.deleteUser(1L);
 
             assertNotNull(user.getDeletedAt());
+        }
+    }
+
+    @Nested
+    @Order(4)
+    @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+    class FindReviewsTests {
+        @Test
+        @Order(1)
+        void 사용자_리뷰_조회_성공() {
+            LocalDateTime now = LocalDateTime.now();
+            List<UserReviewResponse> userReviewResponseList = List.of(
+                    new UserReviewResponse(1L, "review1", 5.0, now, 1L, "program1", null),
+                    new UserReviewResponse(2L, "review2", 4.5, now, 2L, "program2", null)
+            );
+            Pageable pageable = PageRequest.of(0, 10, Sort.by("createdAt").descending());
+            PageImpl<UserReviewResponse> userReviewResponsePage = new PageImpl<>(userReviewResponseList, pageable, userReviewResponseList.size());
+
+            given(reviewRepository.findActiveByUserId(anyLong(), any(Pageable.class))).willReturn(userReviewResponsePage);
+
+            Page<UserReviewResponse> result = userService.findReviews(1L, 1, 10);
+
+            assertNotNull(result);
+            assertEquals(userReviewResponsePage.getTotalElements(), result.getTotalElements());
+            assertEquals(userReviewResponsePage.getTotalPages(), result.getTotalPages());
+            assertEquals(userReviewResponsePage.getNumber(), result.getNumber());
+            assertEquals(userReviewResponsePage.getSize(), result.getSize());
         }
     }
 }

--- a/src/test/java/com/example/nurim/domain/user/service/UserServiceTest.java
+++ b/src/test/java/com/example/nurim/domain/user/service/UserServiceTest.java
@@ -1,16 +1,22 @@
 package com.example.nurim.domain.user.service;
 
 import com.example.nurim.domain.user.dto.request.UpdateNameRequest;
+import com.example.nurim.domain.user.dto.request.UpdatePasswordRequest;
 import com.example.nurim.domain.user.entity.User;
+import com.example.nurim.domain.user.exception.UserException;
 import com.example.nurim.domain.user.repository.UserRepository;
 import org.junit.jupiter.api.*;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.crypto.password.PasswordEncoder;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
 
 @TestClassOrder(ClassOrderer.OrderAnnotation.class)
@@ -18,6 +24,8 @@ import static org.mockito.BDDMockito.given;
 class UserServiceTest {
     @Mock
     private UserRepository userRepository;
+    @Mock
+    private PasswordEncoder passwordEncoder;
     @InjectMocks
     private UserService userService;
 
@@ -36,6 +44,55 @@ class UserServiceTest {
             userService.updateName(1L, request);
 
             assertEquals(request.getName(), user.getName());
+        }
+    }
+
+    @Nested
+    @Order(2)
+    @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+    class UpdatePasswordTests {
+
+        private final User user = new User("temp@gmail.com", "encodedPassword", "name");
+
+        @Test
+        @Order(1)
+        void 비밀번호_수정_현재비밀번호_불일치_실패() {
+            UpdatePasswordRequest request = new UpdatePasswordRequest("oldPassword", "newPassword");
+
+            given(userRepository.findActiveByIdOrElseThrow(anyLong())).willReturn(user);
+            given(passwordEncoder.matches(anyString(), anyString())).willReturn(false);
+
+            UserException thrown = assertThrows(UserException.class, () -> userService.updatePassword(1L, request));
+            assertEquals(HttpStatus.BAD_REQUEST, thrown.getStatus());
+            assertEquals("Current password is incorrect", thrown.getMessage());
+        }
+
+        @Test
+        @Order(2)
+        void 비밀번호_수정_새비밀번호_현재비밀번호_일치_실패() {
+            UpdatePasswordRequest request = new UpdatePasswordRequest("samePassword", "samePassword");
+
+            given(userRepository.findActiveByIdOrElseThrow(anyLong())).willReturn(user);
+            given(passwordEncoder.matches(anyString(), anyString())).willReturn(true);
+
+            UserException thrown = assertThrows(UserException.class, () -> userService.updatePassword(1L, request));
+            assertEquals(HttpStatus.BAD_REQUEST, thrown.getStatus());
+            assertEquals("New password cannot be the same as the current password", thrown.getMessage());
+        }
+
+        @Test
+        @Order(3)
+        void 비밀번호_수정_성공() {
+            String newEncodedPassword = "newEncodedPassword";
+            UpdatePasswordRequest request = new UpdatePasswordRequest("oldPassword", "newPassword");
+
+            given(userRepository.findActiveByIdOrElseThrow(anyLong())).willReturn(user);
+            given(passwordEncoder.matches(anyString(), anyString())).willReturn(true);
+            given(passwordEncoder.encode(anyString())).willReturn(newEncodedPassword);
+
+            userService.updatePassword(1L, request);
+
+            assertEquals(newEncodedPassword, user.getPassword());
         }
     }
 }

--- a/src/test/java/com/example/nurim/domain/user/service/UserServiceTest.java
+++ b/src/test/java/com/example/nurim/domain/user/service/UserServiceTest.java
@@ -1,0 +1,41 @@
+package com.example.nurim.domain.user.service;
+
+import com.example.nurim.domain.user.dto.request.UpdateNameRequest;
+import com.example.nurim.domain.user.entity.User;
+import com.example.nurim.domain.user.repository.UserRepository;
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
+
+@TestClassOrder(ClassOrderer.OrderAnnotation.class)
+@ExtendWith(MockitoExtension.class)
+class UserServiceTest {
+    @Mock
+    private UserRepository userRepository;
+    @InjectMocks
+    private UserService userService;
+
+    @Nested
+    @Order(1)
+    @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+    class UpdateNameTests {
+        @Test
+        @Order(1)
+        void 사용자_이름_수정_성공() {
+            UpdateNameRequest request = new UpdateNameRequest("newName");
+            User user = new User("temp@gmail.com", "encodedPassword", "name");
+
+            given(userRepository.findActiveByIdOrElseThrow(anyLong())).willReturn(user);
+
+            userService.updateName(1L, request);
+
+            assertEquals(request.getName(), user.getName());
+        }
+    }
+}


### PR DESCRIPTION
### 구현 기능

1. 사용자 이름 변경 API
- 같은 이름으로 변경 시 예외 발생 안 함(성공 코드 응답)
2. 사용자 비밀번호 변경 API
3. 회원 탈퇴 API
- 사용자가 작성한 리뷰나 공지사항은 삭제 안 함
- 아직 이용하지 않은 신청 정보가 존재할 때 탈퇴 불가
4. 내가 작성한 리뷰 조회 API
- 리뷰 리포지토리 메서드, dto 추가됨
- 리뷰 엔티티에 Timestamped 상속 추가
5. 신청 내역 조회 API

### 참고
implementation "com.querydsl:querydsl-jpa:5.0.0:jakarta"에 취약점이 있다고 떠서 implementation "com.querydsl:querydsl-jpa:${dependencyManagement.importedProperties['querydsl.version']}:jakarta"로 변경했습니다.
